### PR TITLE
Version 9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,12 @@
 #
 ######################################################################
 #
+# Build 9 (xx/xx/xxxx)
+######################
+#
+# ! pulledpork requires LOCAL_NIDS_RULE_TUNING value to be lower case
+#   to read properly.
+#
 # Build 8 (03/18/2019)
 ######################
 #

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,8 +15,9 @@
 #   to read properly.
 # ! Main menu now properly clears when called from suboption.
 # / Main menu options compacted (no user change).
-# / rule_changes.log now appends to previous log, and rolls over once
+# + rule_changes.log now appends to previous log, and rolls over once
 #   larger than 50M.
+# + Config backups now offer to prune after defined amount of days.
 #
 # Build 8 (03/18/2019)
 ######################

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 #
 # ! pulledpork requires LOCAL_NIDS_RULE_TUNING value to be lower case
 #   to read properly.
+# ! Main menu now properly clears when called from suboption.
 #
 # Build 8 (03/18/2019)
 ######################

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@
 #
 ######################################################################
 #
-# Build 9 (xx/xx/xxxx)
+# Build 9 (03/23/2019)
 ######################
 #
 # ! pulledpork requires LOCAL_NIDS_RULE_TUNING value to be lower case

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,8 @@
 #   to read properly.
 # ! Main menu now properly clears when called from suboption.
 # / Main menu options compacted (no user change).
+# / rule_changes.log now appends to previous log, and rolls over once
+#   larger than 50M.
 #
 # Build 8 (03/18/2019)
 ######################

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 # ! pulledpork requires LOCAL_NIDS_RULE_TUNING value to be lower case
 #   to read properly.
 # ! Main menu now properly clears when called from suboption.
+# / Main menu options compacted (no user change).
 #
 # Build 8 (03/18/2019)
 ######################

--- a/so_utils
+++ b/so_utils
@@ -3,6 +3,7 @@
 # These are all of your configurations for the script.
 #
 # su_editor     - the text editor you want to invoke.
+# retention		- how long to keep backups. (will prompt before delete)
 #
 # NOTE: The "backup" settings are only required if you use the network
 #       backup functions!
@@ -15,6 +16,7 @@
 ######################################################################
 
 su_editor=nano
+retention=30
 
 su_backupUser=
 su_backupHost=
@@ -40,6 +42,10 @@ nrml=$(tput sgr0)
 
 rc_log=/var/log/nsm/rule_changes.log
 sc_log=/var/log/nsm/sid_changes.log
+
+sn_bk=/var/backups/snort
+pp_bk=/var/backups/pulledpork
+rul_bk=/var/backups/rules
 
 
 
@@ -215,13 +221,25 @@ function su_clearBacklog {
 # directory.
 ######################################################################
 function su_editSnort {
-	backup=/var/backups/snort/snort.conf.`date +%m%d%Y_%H%M%S`
+	backup=$sn_bk/snort.conf.`date +%m%d%Y_%H%M%S`
 
-	if ! [[ -d /var/backups/snort ]]; then mkdir /var/backups/snort; fi
+	if ! [[ -d $sn_bk ]]; then mkdir $sn_bk; fi
 
 	cp /etc/nsm/templates/snort/snort.conf $backup
 	printf "Backup created at $backup\n"
 	$su_editor /etc/nsm/templates/snort/snort.conf 2>/dev/null
+
+	count=`find $sn_bk -name "snort.conf.*" -mtime +$retention | wc -l`
+	if [[ $count -gt 0 ]]; then
+		echo "You currently have $count backups older than $retention days."
+		echo -n "Prune? [y/N]: "; read junk
+
+		if [[ "$junk" == [yY] ]]; then
+			find $sn_bk -name "snort.conf.*" -mtime +$retention -exec rm -f {} \;
+			echo "--- Press [Enter] to continue ---"; read -s
+		fi
+	fi
+
 	echo "Make sure to run snort replicate to commit your changes!"
 	echo "--- Press [Enter] to continue ---"; read -s
 }
@@ -236,13 +254,25 @@ function su_editSnort {
 # directory.
 ######################################################################
 function su_editEnSID {
-	backup=/var/backups/pulledpork/enablesid.conf.`date +%m%d%Y_%H%M%S`
+	backup=$pp_bk/enablesid.conf.`date +%m%d%Y_%H%M%S`
 
-	if ! [[ -d /var/backups/pulledpork ]]; then mkdir /var/backups/pulledpork; fi
+	if ! [[ -d $pp_bk ]]; then mkdir $pp_bk; fi
 
 	cp /etc/nsm/pulledpork/enablesid.conf $backup
 	printf "Backup created at $backup\n"
 	$su_editor /etc/nsm/pulledpork/enablesid.conf 2>/dev/null
+
+	count=`find $pp_bk -name "enablesid.conf.*" -mtime +$retention | wc -l`
+	if [[ $count -gt 0 ]]; then
+		echo "You currently have $count backups older than $retention days."
+		echo -n "Prune? [y/N]: "; read junk
+
+		if [[ "$junk" == [yY] ]]; then
+			find $pp_bk -name "enablesid.conf.*" -mtime +$retention -exec rm -f {} \;
+			echo "--- Press [Enter] to continue ---"; read -s
+		fi
+	fi
+
 	echo "Make sure to run rule update to commit your changes!"
 	echo "--- Press [Enter] to continue ---"; read -s
 }
@@ -257,13 +287,25 @@ function su_editEnSID {
 # directory.
 ######################################################################
 function su_editModSID {
-	backup=/var/backups/pulledpork/modifysid.conf.`date +%m%d%Y_%H%M%S`
+	backup=$pp_bk/modifysid.conf.`date +%m%d%Y_%H%M%S`
 
-	if ! [[ -d /var/backups/pulledpork ]]; then mkdir /var/backups/pulledpork; fi
+	if ! [[ -d $pp_bk ]]; then mkdir $pp_bk; fi
 
 	cp /etc/nsm/pulledpork/modifysid.conf $backup
 	printf "Backup created at $backup\n"
 	$su_editor /etc/nsm/pulledpork/modifysid.conf 2>/dev/null
+
+	count=`find $pp_bk -name "modifysid.conf.*" -mtime +$retention | wc -l`
+	if [[ $count -gt 0 ]]; then
+		echo "You currently have $count backups older than $retention days."
+		echo -n "Prune? [y/N]: "; read junk
+
+		if [[ "$junk" == [yY] ]]; then
+			find $pp_bk -name "modifysid.conf.*" -mtime +$retention -exec rm -f {} \;
+			echo "--- Press [Enter] to continue ---"; read -s
+		fi
+	fi
+
 	echo "Make sure to run rule update to commit your changes!"
 	echo "--- Press [Enter] to continue ---"; read -s
 }
@@ -278,13 +320,25 @@ function su_editModSID {
 # directory.
 ######################################################################
 function su_editDisSID {
-	backup=/var/backups/pulledpork/disablesid.conf.`date +%m%d%Y_%H%M%S`
+	backup=$pp_bk/disablesid.conf.`date +%m%d%Y_%H%M%S`
 
-	if ! [[ -d /var/backups/pulledpork ]]; then mkdir /var/backups/pulledpork; fi
+	if ! [[ -d $pp_bk ]]; then mkdir $pp_bk; fi
 
 	cp /etc/nsm/pulledpork/disablesid.conf $backup
 	printf "Backup created at $backup\n"
 	$su_editor /etc/nsm/pulledpork/disablesid.conf 2>/dev/null
+
+	count=`find $pp_bk -name "disablesid.conf.*" -mtime +$retention | wc -l`
+	if [[ $count -gt 0 ]]; then
+		echo "You currently have $count backups older than $retention days."
+		echo -n "Prune? [y/N]: "; read junk
+
+		if [[ "$junk" == [yY] ]]; then
+			find $pp_bk -name "disablesid.conf.*" -mtime +$retention -exec rm -f {} \;
+			echo "--- Press [Enter] to continue ---"; read -s
+		fi
+	fi
+
 	echo "Make sure to run rule update to commit your changes!"
 	echo "--- Press [Enter] to continue ---"; read -s
 }
@@ -299,13 +353,25 @@ function su_editDisSID {
 # directory.
 ######################################################################
 function su_editlocalRules {
-	backup=/var/backups/rules/local.rules.`date +%m%d%Y_%H%M%S`
+	backup=$rul_bk/local.rules.`date +%m%d%Y_%H%M%S`
 
-	if ! [[ -d /var/backups/rules ]]; then mkdir /var/backups/rules; fi
+	if ! [[ -d $rul_bk ]]; then mkdir $rul_bk; fi
 
 	cp /etc/nsm/rules/local.rules $backup
 	printf "Backup created at $backup\n"
 	$su_editor /etc/nsm/rules/local.rules 2>/dev/null
+
+	count=`find $rul_bk -name "local.rules.*" -mtime +$retention | wc -l`
+	if [[ $count -gt 0 ]]; then
+		echo "You currently have $count backups older than $retention days."
+		echo -n "Prune? [y/N]: "; read junk
+
+		if [[ "$junk" == [yY] ]]; then
+			find $rul_bk -name "local.rules.*" -mtime +$retention -exec rm -f {} \;
+			echo "--- Press [Enter] to continue ---"; read -s
+		fi
+	fi
+
 	echo "Make sure to run rule update to commit your changes!"
 	echo "--- Press [Enter] to continue ---"; read -s
 }

--- a/so_utils
+++ b/so_utils
@@ -558,19 +558,19 @@ printf "Security Onion Utilities (ver. $su_version)
 
 		echo -n "Option: "; read junk
 
-		if [[ "$junk" == 1 ]] || [[ "$junk" == [sS] ]]; then
+		if [[ "$junk" == [1sS] ]]; then
 			clear
 			su_soStat
 
-		elif [[ "$junk" == 2 ]] || [[ "$junk" == [uU] ]]; then
+		elif [[ "$junk" == [2uU] ]]; then
 			clear
 			su_ruleUpdate
 
-		elif [[ "$junk" == 3 ]] || [[ "$junk" == [rR] ]]; then
+		elif [[ "$junk" == [3rR] ]]; then
 			clear
 			su_snortReplicate
       
-		elif [[ "$junk" == 4 ]] || [[ "$junk" == [iI] ]]; then
+		elif [[ "$junk" == [4iI] ]]; then
 			clear
 			su_signatureUpdate
 
@@ -638,7 +638,7 @@ printf "Security Onion Utilities (ver. $su_version)
 			clear
 			su_createDesktop
 
-		elif [[ "$junk" == 0 ]] || [[ "$junk" == [qQ] ]]; then
+		elif [[ "$junk" == [0qQ] ]]; then
 			clear
 			exit
 

--- a/so_utils
+++ b/so_utils
@@ -104,7 +104,7 @@ function su_signatureUpdate {
 	searchdir=/media
 	snort_version=`snort -V 2>&1 | grep -Po "(\d+\.){3}\d+" | tr -d .`
 
-	if ! [[ "$local_tuning" == [yY][eE][sS] ]]; then
+	if ! [[ "$local_tuning" == "yes" ]]; then
 		junk=
 		echo "Local NIDS tuning is not enabled! Manually installing signatures will not take effect until enabled."
 		echo -n "Would you like to enable local NIDS tuning? [Y/n]: "; read junk; junk=${junk:=Y}

--- a/so_utils
+++ b/so_utils
@@ -536,9 +536,8 @@ Icon=/usr/share/pixmaps/security-onion.ico" > $desktopPath/securityonion-utiliti
 #  0. Quit
 ######################################################################
 function su_mainMenu {
-	clear
-
 	while [[ 2 -gt 1 ]]; do
+		clear
 printf "Security Onion Utilities (ver. $su_version)
 
 === Tools				=== Backups

--- a/so_utils
+++ b/so_utils
@@ -38,6 +38,9 @@ uline=$(tput smul)
 bu=${bold}${uline}
 nrml=$(tput sgr0)
 
+rc_log=/var/log/nsm/rule_changes.log
+sc_log=/var/log/nsm/sid_changes.log
+
 
 
 ######################################################################
@@ -70,8 +73,8 @@ function su_soStat {
 ######################################################################
 # Rule Update.
 #
-# This runs rule-update, and also logs differential changes to the
-# downloaded.rules file for review.
+# This runs rule-update, logs differential changes to the
+# downloaded.rules file for review, and archives logs over 50M.
 ######################################################################
 function su_ruleUpdate {
 	junk=
@@ -80,12 +83,15 @@ function su_ruleUpdate {
 	rule-update
 	cp /etc/nsm/rules/downloaded.rules /tmp/rules/new.rules
 
-	tail -n +`grep -on "Begin Changes" /var/log/nsm/sid_changes.log | tail -1 | cut -d":" -f1` /var/log/nsm/sid_changes.log > /var/log/nsm/rule_changes.log
-	diff /tmp/rules/old.rules /tmp/rules/new.rules >> /var/log/nsm/rule_changes.log
-	sed -i "s/^</\n\n</g" /var/log/nsm/rule_changes.log
+	if ! [ -f "$rc_log" ]; then touch $rc_log; fi
+	size=`du $rc_log | grep -Po "\d*"`
+	if [[ $size -gt 50000 ]]; then count=`ls ${rc_log}.*.tar.gz 2>/dev/null | wc -l`; cd /var/log/nsm; tar -cvf rule_changes.log.$(($count+1)).tar.gz --remove-files rule_changes.log; fi
+
+	tail -n +`grep -on "Begin Changes" $sc_log | tail -1 | cut -d":" -f1` $sc_log >> $rc_log
+	diff /tmp/rules/old.rules /tmp/rules/new.rules >> $rc_log
 
 	echo -n "Review changes? [y/N]: "; read junk
-	if [[ "$junk" == [yY] ]]; then $su_editor /var/log/nsm/rule_changes.log 2>/dev/null; fi
+	if [[ "$junk" == [yY] ]]; then $su_editor $rc_log 2>/dev/null; fi
 }
 
 

--- a/so_utils
+++ b/so_utils
@@ -34,7 +34,7 @@ su_backupArgs=
 # https://github.com/dsabecky/securityonion_utilities/blob/master/CHANGELOG
 ######################################################################
 
-su_version=8
+su_version=9
 bold=$(tput bold)
 uline=$(tput smul)
 bu=${bold}${uline}


### PR DESCRIPTION
Fixed #9 - pulledpork requires LOCAL_NIDS_RULE_TUNING value to be lower case to read properly.
Fixed #10 - Main menu now properly clears when called from suboption.
Changed #12 - Main menu options compacted (no user change).
Added #13  - rule_changes.log now appends to previous log, and rolls over once larger than 50M.
Added #11 - Config backups now offer to prune after defined amount of days.